### PR TITLE
Set up authentification for the two user models

### DIFF
--- a/app/controllers/concerns/accessible.rb
+++ b/app/controllers/concerns/accessible.rb
@@ -1,0 +1,19 @@
+module Accessible
+    extend ActiveSupport::Concern
+    included do
+    before_action :check_user
+    end
+
+    protected
+    def check_user
+    if current_retailer
+        flash.clear
+        # if you have rails_admin. You can redirect anywhere really
+        redirect_to(vouchers_path) and return
+    elsif current_user
+        flash.clear
+        # The authenticated root path can be defined in your routes.rb in: devise_scope :user do...
+        redirect_to(receipts_index_path) and return
+    end
+    end
+end

--- a/app/controllers/retailers/confirmations_controller.rb
+++ b/app/controllers/retailers/confirmations_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Retailers::ConfirmationsController < Devise::ConfirmationsController
+  include Accessible
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/retailers/omniauth_callbacks_controller.rb
+++ b/app/controllers/retailers/omniauth_callbacks_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Retailers::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  include Accessible
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/retailers/passwords_controller.rb
+++ b/app/controllers/retailers/passwords_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Retailers::PasswordsController < Devise::PasswordsController
+  include Accessible
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/retailers/registrations_controller.rb
+++ b/app/controllers/retailers/registrations_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Retailers::RegistrationsController < Devise::RegistrationsController
+  include Accessible
+  skip_before_action :check_user, except: [:new, :create]
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/retailers/sessions_controller.rb
+++ b/app/controllers/retailers/sessions_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Retailers::SessionsController < Devise::SessionsController
+  include Accessible
+  skip_before_action :check_user, only: :destroy
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/retailers/unlocks_controller.rb
+++ b/app/controllers/retailers/unlocks_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Retailers::UnlocksController < Devise::UnlocksController
+  include Accessible
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  include Accessible
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  include Accessible
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  include Accessible
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  include Accessible
+  skip_before_action :check_user, except: [:new, :create]
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  include Accessible
+  skip_before_action :check_user, only: :destroy
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  include Accessible
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,13 @@
 module ApplicationHelper
+    def current_auth_resource
+        if retailer_signed_in?
+            current_retailer
+        else
+            current_user
+        end
+    end
+
+    def current_ability
+        @current_ability or @current_ability = Ability.new(current_auth_resource)
+    end
 end

--- a/app/models/retailer.rb
+++ b/app/models/retailer.rb
@@ -6,6 +6,7 @@ class Retailer < ApplicationRecord
 
   has_many :tills
   has_many :items
+  has_many :vouchers
 
   enum brand: [:carrefour_market, :monoprix, :auchan]
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,17 @@ Rails.application.routes.draw do
   get 'receipts/index'
   get 'receipts/index/filter', to: 'receipts#filter'
   get 'receipts/:id', to: 'receipts#show', as: 'receiptshow'
-  devise_for :retailers
+  devise_for :retailers,
+              path: '/retailer',
+              path_names: {sign_in: 'login', sign_up: 'signup', edit: 'profile'},
+              controllers: {
+                sessions: 'retailers/sessions'
+              }
   devise_for :users,
-              path: '',
-              path_names: {sign_in: 'login', sign_up: 'signup', edit: 'profile'}
+              path: '/user',
+              path_names: {sign_in: 'login', sign_up: 'signup', edit: 'profile'},
+              controllers: {
+                sessions: 'users/sessions'
+              }
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2021_09_08_195626) do
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
This all things set up the possibility to login/sign_up etc as a User or as a Retailer. Each type of app_user now have its own routes and everything : 

`/user/login`

![image](https://user-images.githubusercontent.com/75135824/133989898-3ddc889b-e463-4a56-aa73-bc7b9db7dcd4.png)

redirects to the classic user_dashboard 
![image](https://user-images.githubusercontent.com/75135824/133990068-07cb93d5-0ce0-43c4-ade2-8e381532e21b.png)

when : `/retailer/login`

![image](https://user-images.githubusercontent.com/75135824/133990320-b035007d-1921-4944-abb2-3987c6ffeffe.png)

Redirects to the retailer pages to come (in my exemple the vouchers index)
![image](https://user-images.githubusercontent.com/75135824/133990445-48fb4026-ebf1-453a-927a-12a237dfd388.png)
